### PR TITLE
fixed postgresql notifications

### DIFF
--- a/db-doc/db/scribblings/connect.scrbl
+++ b/db-doc/db/scribblings/connect.scrbl
@@ -46,7 +46,8 @@ Base connections are made using the following functions.
                    void]
                   [#:notification-handler notification-handler
                    (or/c 'output 'error output-port?
-                         (-> string? any))
+                         (-> string? any)
+			 (-> string? string? any))
                    void])
          connection?]{
 
@@ -89,19 +90,23 @@ Base connections are made using the following functions.
   @racket[ssl-load-private-key!]. SSL may only be used with TCP
   connections, not with local sockets.
 
-  The @racket[notice-handler] is called on notice messages
-  received asynchronously from the server. A common example is notice
-  of an index created automatically for a table's primary key. The
+  @margin-note{The ability to include a payload in a notification was
+    added in PostgreSQL 9.0.}
+
+  The @racket[notice-handler] is called on notice messages received
+  asynchronously from the server. A common example is notice of an
+  index created automatically for a table's primary key. The
   @racket[notice-handler] function takes two string arguments: the
   condition's SQLSTATE and a message. The
   @racket[notification-handler] is called in response to an event
   notification (see the @tt{LISTEN} and @tt{NOTIFY} statements); its
-  argument is the name of the event as a string. An output port may be
-  supplied instead of a procedure, in which case a message is printed
-  to the given port. Finally, the symbol @racket['output] causes the
-  message to be printed to the current output port, and
-  @racket['error] causes the message to be printed to the current
-  error port.
+  arguments are the name of the channel, and the payload, as strings.
+  If the handler only accepts a single argument, then it will be
+  called without the payload. An output port may be supplied instead
+  of a procedure, in which case a message is printed to the given
+  port. Finally, the symbol @racket['output] causes the message to be
+  printed to the current output port, and @racket['error] causes the
+  message to be printed to the current error port.
 
   If the connection cannot be made, an exception is raised.
 

--- a/db-lib/db/private/postgresql/connection.rkt
+++ b/db-lib/db/private/postgresql/connection.rkt
@@ -143,8 +143,11 @@
          (let ([code (cdr (assq 'code properties))]
                [message (cdr (assq 'message properties))])
            (add-delayed-call! (lambda () (notice-handler code message))))]
-        [(struct NotificationResponse (pid condition info))
-         (add-delayed-call! (lambda () (notification-handler condition)))]
+        [(struct NotificationResponse (pid channel info))
+         (add-delayed-call! (lambda ()
+			      (if (procedure-arity-includes? notification-handler 2)
+				  (notification-handler channel info)
+				  (notification-handler channel))))]
         [(struct ParameterStatus (name value))
          (cond [(equal? name "client_encoding")
                 (unless (equal? value "UTF8")

--- a/db-lib/db/private/postgresql/main.rkt
+++ b/db-lib/db/private/postgresql/main.rkt
@@ -62,12 +62,12 @@
   (guess-socket-path/paths 'postgresql-guess-socket-path socket-paths))
 
 ;; make-print-notification : output-port -> string -> void
-(define ((make-print-notification out) condition)
+(define ((make-print-notification out) channel payload)
   (fprintf (case out
              ((output) (current-output-port))
              ((error) (current-error-port))
              (else out))
-           "notification: ~a\n" condition))
+           "notification: ~a ~a\n" channel payload))
 
 (define (postgresql-password-hash user password)
   (bytes->string/latin-1 (password-hash user password)))

--- a/db-lib/db/private/postgresql/message.rkt
+++ b/db-lib/db/private/postgresql/message.rkt
@@ -337,13 +337,13 @@
   (with-length-in p #\n
     (make-NoData)))
 
-(define-struct NotificationResponse (process-id condition info) #:transparent)
+(define-struct NotificationResponse (process-id channel payload) #:transparent)
 (define (parse:NotificationResponse p)
   (with-length-in p #\A
     (let* ([process-id (io:read-int32 p)]
-           [condition (io:read-int32 p)]
-           [info (io:read-int32 p)])
-      (make-NotificationResponse process-id condition info))))
+           [channel (io:read-null-terminated-string p)]
+           [payload (io:read-null-terminated-string p)])
+      (make-NotificationResponse process-id channel payload))))
 
 (define-struct ParameterDescription (type-oids) #:transparent)
 (define (parse:ParameterDescription p)


### PR DESCRIPTION
There are two issues with the implementation of postgresql notifications:
1) the definition of NotificationResponse in message.rkt is wrong; it should be two null-terminated strings, not two ints. (The message parser will error out in integer-bytes->integer if you get a notification on a channel with a one or two byte name.)
2) there isn't any way to get at the payload of the notifications. The ability to send notifications with payloads was added in 9.0, but the protocol supported them all the way back in 7.4. (see http://www.postgresql.org/docs/7.4/static/protocol-message-formats.html)

I'd be happy to make adjustments, etc