### PR TITLE
jsonb & void support. more types on the unsupported list

### DIFF
--- a/db-doc/db/scribblings/sql-types.scrbl
+++ b/db-doc/db/scribblings/sql-types.scrbl
@@ -83,6 +83,7 @@ along with their corresponding Racket representations.
   @racket['varbit]        @& @tt{varbit}             @& @racket[bit-vector?] @//
 
   @racket['json]          @& @tt{json}               @& @racket[jsexpr?] @//
+  @racket['jsonb]         @& @tt{jsonb}              @& @racket[jsexpr?] @//
   @racket['int4range]     @& @tt{int4range}          @& @racket[pg-range-or-empty?] @//
   @racket['int8range]     @& @tt{int8range}          @& @racket[pg-range-or-empty?] @//
   @racket['numrange]      @& @tt{numrange}           @& @racket[pg-range-or-empty?] @//


### PR DESCRIPTION
Included:
* send / receive support for json and jsonb types.
* receive support for void. (trying to send void seems like it's probably an error)
* added some unsupported types to the list.
