### PR TITLE
Add a package version and a @history annotation for uuid changes

### DIFF
--- a/db-doc/db/scribblings/sql-types.scrbl
+++ b/db-doc/db/scribblings/sql-types.scrbl
@@ -170,6 +170,8 @@ PostgreSQL defines many other types, such as network addresses and row
 types. These are currently not supported, but support may be added in
 future versions of this library.
 
+@history[#:changed "1.1" @elem{Added support for the @racket['uuid] type.}]
+
 
 @subsection[#:tag "mysql-types"]{MySQL Types}
 

--- a/db-doc/db/scribblings/util.scrbl
+++ b/db-doc/db/scribblings/util.scrbl
@@ -231,7 +231,10 @@ dashes, in the following pattern:
 
 The digits themselves are case-insensitive, accepting both uppercase
 and lowercase characters. Otherwise, if @racket[v] is not a string
-matching the above pattern, this function returns @racket[#f].}
+matching the above pattern, this function returns @racket[#f].
+
+@history[#:added "1.1"]
+}
 
 @deftogether[[
 @defstruct*[pg-box

--- a/db-doc/info.rkt
+++ b/db-doc/info.rkt
@@ -1,5 +1,7 @@
 #lang info
 
+(define version "1.1")
+
 (define collection 'multi)
 
 (define deps '("base"))

--- a/db-lib/info.rkt
+++ b/db-lib/info.rkt
@@ -1,5 +1,7 @@
 #lang setup/infotab
 
+(define version "1.1")
+
 (define collection 'multi)
 (define deps '("srfi-lite-lib"
                ["base" #:version "6.2.900.17"]

--- a/db-test/info.rkt
+++ b/db-test/info.rkt
@@ -1,5 +1,7 @@
 #lang info
 
+(define version "1.1")
+
 (define collection 'multi)
 
 (define deps '("base"

--- a/db/info.rkt
+++ b/db/info.rkt
@@ -1,5 +1,7 @@
 #lang info
 
+(define version "1.1")
+
 (define collection 'multi)
 
 (define deps


### PR DESCRIPTION
I would like to depend on the existence of support for Postgres UUIDs, so this adds a version to the package(s) and `@history` annotations where relevant.