### PR TITLE
add subsystem isolation level symbols to transaction contracts

### DIFF
--- a/db-lib/db/base.rkt
+++ b/db-lib/db/base.rkt
@@ -182,7 +182,21 @@
 
  [start-transaction
   (->* (connection?)
-       (#:isolation (or/c 'serializable 'repeatable-read 'read-committed 'read-uncommitted #f)
+       (#:isolation
+        (or/c
+         ;; generic
+         'serializable
+         'repeatable-read
+         'read-committed
+         'read-uncommitted
+         ;; postgresql
+         'read-only
+         'read-write
+         ;; sqlite3
+         'deferred
+         'immediate
+         'exclusive
+         '#f)
         #:option any/c)
        void?)]
  [commit-transaction
@@ -195,7 +209,20 @@
   (-> connection? boolean?)]
  [call-with-transaction
   (->* (connection? (-> any))
-       (#:isolation (or/c 'serializable 'repeatable-read 'read-committed 'read-uncommitted #f)
+       (#:isolation (or/c
+                     ;; generic
+                     'serializable
+                     'repeatable-read
+                     'read-committed
+                     'read-uncommitted
+                     ;; postgresql
+                     'read-only
+                     'read-write
+                     ;; sqlite3
+                     'deferred
+                     'immediate
+                     'exclusive
+                     '#f)
         #:option any/c)
        any)]
 


### PR DESCRIPTION
Add subsystem-specific transaction isolation symbols 
to the contracts for `start-transaction` & `call-with-transasction`
per the [documentation](https://docs.racket-lang.org/db/query-api.html?q=start-transaction#%28def._%28%28lib._db%2Fbase..rkt%29._start-transaction%29%29).