### PR TITLE
Fix socket leak in postgresql-connect

### DIFF
--- a/db-lib/db/private/cassandra/main.rkt
+++ b/db-lib/db/private/cassandra/main.rkt
@@ -20,5 +20,9 @@
       [(yes) (ssl-connect server port ssl-context)]))
   (define c (new connection% (inport in) (outport out)))
   (when debug? (send c debug #t))
-  (send c start-connection-protocol user password)
+  (with-handlers
+     ([exn? (lambda (e)
+              (send c disconnect* #f)
+              (raise e))])
+    (send c start-connection-protocol user password))
   c)

--- a/db-test/tests/db/programs/startup-leak-test.rkt
+++ b/db-test/tests/db/programs/startup-leak-test.rkt
@@ -1,0 +1,92 @@
+#lang racket/base
+(require racket/os
+         racket/port)
+
+#|
+This program tests that open files are cleaned up when an exception is
+raised during connection start.
+
+`lsof' is required to count the number of open files.
+|#
+
+(define lsof (find-executable-path "lsof"))
+
+(unless lsof
+  (error "This test requires the lsof executable in PATH"))
+
+(define (count-open-files)
+  (parameterize ([current-subprocess-custodian-mode 'kill]
+                 [current-custodian (make-custodian)])
+    (call-with-continuation-barrier
+     (lambda ()
+       (dynamic-wind
+         void
+         (lambda ()
+           (define-values (proc out in err)
+             (subprocess #f #f #f lsof "-wnPp" (number->string (getpid))))
+           (thread
+             (lambda () (copy-port err (current-error-port))))
+           (begin0
+             (sub1 (length (port->lines out)))
+             (subprocess-wait proc)
+             (unless (equal? 0 (subprocess-status proc))
+               (error "lsof returned non-zero status"))))
+         (lambda ()
+           (custodian-shutdown-all (current-custodian))))))))
+
+(module+ main
+  (require racket/tcp
+           racket/match
+           racket/cmdline
+           racket/exn
+           db)
+
+  (define the-dsn (make-parameter 'pg))
+  (define verbose? (make-parameter #f))
+
+  (command-line
+    #:once-each
+    [("-v" "--verbose") "Enable verbose output" (verbose? #t)]
+    #:args (dsn)
+    (the-dsn (string->symbol dsn)))
+
+  (define listener (tcp-listen 0 4 #f "127.0.0.1"))
+  (match-define-values (_ listen-port _ _) (tcp-addresses listener #t))
+
+  (define connection-attempts (box 0))
+  (void
+    (thread
+      (lambda ()
+        (let loop ()
+          (define-values (in out) (tcp-accept listener))
+          (close-input-port in)
+          (close-output-port out)
+          (set-box! connection-attempts (add1 (unbox connection-attempts)))
+          (loop)))))
+
+  (define (maybe-log-exn e)
+    (when (verbose?)
+      (printf "Exception in dsn-connect: ~a~n" (exn->string e))))
+
+  (define open-files-start (count-open-files))
+  (define expected-connection-attempts
+    (for*/sum ([i 100]
+               [ssl '(yes no)])
+      (with-handlers
+         ([exn:fail? maybe-log-exn])
+        (dsn-connect (the-dsn) #:server "127.0.0.1" #:port listen-port #:ssl ssl))
+      1))
+  (define open-files-end (count-open-files))
+
+  (unless (= (unbox connection-attempts) expected-connection-attempts)
+    (error "expected number of connection attempts not made, try --verbose"))
+
+  (when (> open-files-end (+ 5 open-files-start))
+    (printf "Started with ~a open files and ended with ~a, files are leaking~n"
+            open-files-start
+            open-files-end)
+    (exit 1))
+
+  (printf "Test passed~n"))
+
+(module+ test)


### PR DESCRIPTION
When the underlying connection is reset during `postgresql-connect`, there is a small window where an exception can be raised without cleaning up the connection's ports. We caught this when a long-running process ran out of available file descriptors.

To reproduce, set up a server that accepts and immediately closes incoming connections:

```
$ socat TCP-LISTEN:1234,reuseaddr,fork OPEN:/dev/null
```

Then run this:

```
#lang racket

(require db)

(let loop ()
  (with-handlers
     ([exn:break? raise]
      [exn? (lambda (e) (displayln (exn-message e)))])
    (postgresql-connect
      #:server "127.0.0.1"
      #:port 1234
      #:database "foo"
      #:debug? #t
      #:user "foo"))
  (sleep 0.5)
  (loop))
```

After some time:

```
$ lsof -n -a -i TCP -c racket | wc -l
     248
```

With this patch, the number of open files stays constant after startup.

I'm not sure if this is the right way to accomplish cleanup. If an `ErrorResponse` had been sent, it looks like `disconnect*` would be called via `recv-message` in `connect:expect-auth`. However, when the connection returns `#<eof>` or is reset in `connect:expect-auth`, nothing ends up calling `disconnect*`.

If you think this is a good way to go about it, I can make the same change to the other drivers as applicable.

Thanks for the great library!