### PR TITLE
Eliminate dependency on "data-doc" package.

### DIFF
--- a/db-doc/db/scribblings/sql-types.scrbl
+++ b/db-doc/db/scribblings/sql-types.scrbl
@@ -544,7 +544,7 @@ values.
 @subsection{Bits}
 
 The @tt{BIT} and @tt{BIT VARYING} (@tt{VARBIT}) SQL types are
-represented by bit-vectors (@racketmodname[data/bit-vector]).
+represented by bit-vectors (@racketmodname[data/bit-vector #:indirect]).
 
 The following functions are provided for backwards compatibility. They
 are deprecated and will be removed in a future release of Racket.
@@ -566,7 +566,7 @@ are deprecated and will be removed in a future release of Racket.
 @defproc[(list->sql-bits [lst (listof boolean?)]) sql-bits?]
 @defproc[(string->sql-bits [s string?]) sql-bits?]]]{
 
-Deprecated; use @racketmodname[data/bit-vector] instead.
+Deprecated; use @racketmodname[data/bit-vector #:indirect] instead.
 
 }
 

--- a/db-doc/info.rkt
+++ b/db-doc/info.rkt
@@ -4,8 +4,7 @@
 
 (define deps '("base"))
 
-(define build-deps '("data-doc"
-                     "srfi-lite-lib"
+(define build-deps '("srfi-lite-lib"
                      "web-server-doc"
                      "base"
                      "scribble-lib"


### PR DESCRIPTION
However, there are references to `bit-vector?` that don't
get linked currently on
https://docs.racket-lang.org/db/sql-types.html

If we want those links, then this needs a different fix.