### PR TITLE
postgresql: add support for cancelation

### DIFF
--- a/db-doc/db/scribblings/connect.scrbl
+++ b/db-doc/db/scribblings/connect.scrbl
@@ -142,6 +142,11 @@ Base connections are made using the following functions.
   If none of the attempted paths exist, an exception is raised.
 }
 
+@defproc[(postgresql-cancel [conn connection?]) void?]{
+
+  Attempts to cancel any in-progress queries issued by @racket[conn].
+}
+
 @defproc[(mysql-connect [#:user user string?]
                   [#:database database (or/c string? #f) #f]
                   [#:server server string? "localhost"]

--- a/db-lib/db/main.rkt
+++ b/db-lib/db/main.rkt
@@ -8,7 +8,8 @@
  ["private/postgresql/main.rkt"
   (postgresql-connect
    postgresql-guess-socket-path
-   postgresql-password-hash)]
+   postgresql-password-hash
+   postgresql-cancel)]
  ["private/mysql/main.rkt"
   (mysql-connect
    mysql-guess-socket-path
@@ -46,6 +47,8 @@
   (-> path-string?)]
  [postgresql-password-hash
   (-> string? string? string?)]
+ [postgresql-cancel
+  (-> connection? void?)]
 
  ;; Duplicates contracts at mysql.rkt
  [mysql-connect

--- a/db-lib/db/postgresql.rkt
+++ b/db-lib/db/postgresql.rkt
@@ -23,4 +23,6 @@
  [postgresql-guess-socket-path
   (-> path-string?)]
  [postgresql-password-hash
-  (-> string? string? string?)])
+  (-> string? string? string?)]
+ [postgresql-cancel
+  (-> connection? void?)])


### PR DESCRIPTION
This adds support for canceling Postgres queries according to [53.2.8. Canceling Requests in Progress](https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.10).  I don't love the `connect&attach` stuff, but I wanted to minimize the number of changes, and the `ssl-context` needs to be carried forward in case the server only accepts TLS connections. I don't feel strongly about adding the `postgresql-cancel` procedure, and would be happy with just the new `cancel` method on `postgresql-connection<%>` for now if you feel that eventually you might want to add a more general `connection-cancel` procedure that works on other connection types as well down the line.