### PR TITLE
Add tests and docs for `prepare` accepting a virtual statement

### DIFF
--- a/db-doc/db/scribblings/query.scrbl
+++ b/db-doc/db/scribblings/query.scrbl
@@ -462,7 +462,9 @@ closed.
   statement holds its connection link weakly; a reference to a
   prepared statement will not keep a connection from being garbage
   collected.
-}
+
+@history[#:changed "1.10" @elem{Changed to accept @tech{virtual
+            statements} in addition to strings.}]}
 
 @defproc[(prepared-statement? [x any/c]) boolean?]{
 

--- a/db-lib/info.rkt
+++ b/db-lib/info.rkt
@@ -1,10 +1,10 @@
 #lang setup/infotab
 
-(define version "1.9")
+(define version "1.10")
 
 (define collection 'multi)
 (define deps '("srfi-lite-lib"
-               ["base" #:version "8.0.0.7"]
+               ["base" #:version "8.15.0.2"]
                "unix-socket-lib"
                ["sasl-lib" #:version "1.1"]))
 

--- a/db-test/tests/db/db/query.rkt
+++ b/db-test/tests/db/db/query.rkt
@@ -18,6 +18,8 @@
 ;;   'string = query w/ string
 ;;   'prepare = query w/ prepared
 ;;   'bind = query w/ prepared+bound
+;;   'gen = query w/ virtual-statement
+;;   'gen+prepare = query w/ virtual-statement+prepare
 (define-syntax-rule (Q* prep-mode function obj stmt arg ...)
   (Q** prep-mode function obj (sql stmt) (list arg ...)))
 (define (Q** prep-mode function obj stmt args)
@@ -26,6 +28,7 @@
     ((prepare) (apply function obj (prepare obj stmt) args))
     ((bind) (function obj (bind-prepared-statement (prepare obj stmt) args)))
     ((gen) (apply function obj (virtual-statement stmt) args))
+    ((gen+prepare) (apply function obj (prepare obj (virtual-statement stmt)) args))
     (else 'Q* "bad prep-mode: ~e" prep-mode)))
 
 ;; fixintconst : Integer/sql-null -> Any
@@ -142,7 +145,9 @@
               (for ([(x y) (in-query c (bind-prepared-statement (prepare c stmt) (list 2)))])
                 0))
              ((gen)
-              (for ([(x y) (in-query c (virtual-statement stmt) 2)]) 0)))))))
+              (for ([(x y) (in-query c (virtual-statement stmt) 2)]) 0))
+             ((gen+prepare)
+              (for ([(x y) (in-query c (prepare c (virtual-statement stmt)) 2)]) 0)))))))
     ))
 
 (define in-query-tests
@@ -710,6 +715,7 @@
     (simple-tests 'prepare)
     (simple-tests 'bind)
     (simple-tests 'gen)
+    (simple-tests 'gen+prepare)
     in-query-tests
     low-level-tests
     tx-tests


### PR DESCRIPTION
This PR depends on racket/racket#5093 being merged, which updates the actual implementation of `prepare` in base.

This change updates the version constraint on `base` even though no code has changed in `db-lib`, which allows a lower bound on `db-lib` to guarantee that the functionality will be available. That allows a `history` annotation to be included in the docs for `prepare`.